### PR TITLE
Add REST router and simple API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,20 @@
 # welldocphp
-welldocphp
+Simple PHP MVC application with a small REST API.
+
+## Usage
+
+Run `composer install` to generate the autoloader.
+Then serve the application with PHP's built-in server:
+
+```
+php -S localhost:8000 index.php
+```
+
+Available routes:
+
+- `GET /` - Home page.
+- `GET /items` - List all items.
+- `GET /items/{id}` - Show single item.
+- `POST /items` - Create item.
+- `PUT /items/{id}` - Update item.
+- `DELETE /items/{id}` - Delete item.

--- a/app/controllers/HomeController.php
+++ b/app/controllers/HomeController.php
@@ -2,13 +2,17 @@
 namespace app\controllers;
 
 use app\models\HomeModel;
+use app\core\RequestInterface;
+use app\core\ResponseInterface;
+use app\core\View;
 
 class HomeController
 {
-    public function index()
+    public function index(RequestInterface $request, ResponseInterface $response): void
     {
         $model = new HomeModel();
         $message = $model->getMessage();
-        require __DIR__ . '/../views/home.php';
+        $view = new View();
+        $response->setBody($view->render('home', ['message' => $message]));
     }
 }

--- a/app/controllers/ItemsController.php
+++ b/app/controllers/ItemsController.php
@@ -1,0 +1,65 @@
+<?php
+namespace app\controllers;
+
+use app\core\RequestInterface;
+use app\core\ResponseInterface;
+use app\models\ItemsModel;
+
+class ItemsController
+{
+    private ItemsModel $model;
+
+    public function __construct()
+    {
+        $this->model = new ItemsModel();
+    }
+
+    public function index(RequestInterface $request, ResponseInterface $response): void
+    {
+        $items = $this->model->all();
+        $response->setBody(json_encode($items));
+    }
+
+    public function show(RequestInterface $request, ResponseInterface $response): void
+    {
+        $id = (int)$request->getParam('id');
+        $item = $this->model->find($id);
+        if ($item) {
+            $response->setBody(json_encode($item));
+        } else {
+            $response->setStatusCode(404);
+            $response->setBody(json_encode(['error' => 'Not found']));
+        }
+    }
+
+    public function create(RequestInterface $request, ResponseInterface $response): void
+    {
+        $item = $this->model->create($request->getBody());
+        $response->setStatusCode(201);
+        $response->setBody(json_encode($item));
+    }
+
+    public function update(RequestInterface $request, ResponseInterface $response): void
+    {
+        $id = (int)$request->getParam('id');
+        $item = $this->model->update($id, $request->getBody());
+        if ($item) {
+            $response->setBody(json_encode($item));
+        } else {
+            $response->setStatusCode(404);
+            $response->setBody(json_encode(['error' => 'Not found']));
+        }
+    }
+
+    public function delete(RequestInterface $request, ResponseInterface $response): void
+    {
+        $id = (int)$request->getParam('id');
+        if ($this->model->delete($id)) {
+            $response->setStatusCode(204);
+            $response->setBody('');
+        } else {
+            $response->setStatusCode(404);
+            $response->setBody(json_encode(['error' => 'Not found']));
+        }
+    }
+}

--- a/app/core/Request.php
+++ b/app/core/Request.php
@@ -7,6 +7,7 @@ class Request implements RequestInterface
     private string $uri;
     private array $query;
     private array $body;
+    private array $params = [];
 
     public function __construct()
     {
@@ -34,5 +35,20 @@ class Request implements RequestInterface
     public function getBody(): array
     {
         return $this->body;
+    }
+
+    public function setParams(array $params): void
+    {
+        $this->params = $params;
+    }
+
+    public function getParam(string $name): ?string
+    {
+        return $this->params[$name] ?? null;
+    }
+
+    public function getParams(): array
+    {
+        return $this->params;
     }
 }

--- a/app/core/RequestInterface.php
+++ b/app/core/RequestInterface.php
@@ -7,4 +7,7 @@ interface RequestInterface
     public function getUri(): string;
     public function getQueryParams(): array;
     public function getBody(): array;
+    public function setParams(array $params): void;
+    public function getParam(string $name): ?string;
+    public function getParams(): array;
 }

--- a/app/core/View.php
+++ b/app/core/View.php
@@ -1,0 +1,17 @@
+<?php
+namespace app\core;
+
+class View
+{
+    public function render(string $template, array $params = []): string
+    {
+        $path = __DIR__ . '/../views/' . $template . '.php';
+        if (!file_exists($path)) {
+            return '';
+        }
+        extract($params);
+        ob_start();
+        require $path;
+        return ob_get_clean();
+    }
+}

--- a/app/core/helpers.php
+++ b/app/core/helpers.php
@@ -1,0 +1,7 @@
+<?php
+namespace app\core;
+
+function user_call_func(callable $handler, RequestInterface $request, ResponseInterface $response): void
+{
+    call_user_func($handler, $request, $response);
+}

--- a/app/models/ItemsModel.php
+++ b/app/models/ItemsModel.php
@@ -1,0 +1,47 @@
+<?php
+namespace app\models;
+
+class ItemsModel
+{
+    private static array $items = [
+        1 => ['id' => 1, 'name' => 'Item 1'],
+        2 => ['id' => 2, 'name' => 'Item 2'],
+    ];
+
+    public function all(): array
+    {
+        return array_values(self::$items);
+    }
+
+    public function find(int $id): ?array
+    {
+        return self::$items[$id] ?? null;
+    }
+
+    public function create(array $data): array
+    {
+        $id = empty(self::$items) ? 1 : max(array_keys(self::$items)) + 1;
+        $data['id'] = $id;
+        self::$items[$id] = $data;
+        return $data;
+    }
+
+    public function update(int $id, array $data): ?array
+    {
+        if (!isset(self::$items[$id])) {
+            return null;
+        }
+        self::$items[$id] = array_merge(self::$items[$id], $data);
+        self::$items[$id]['id'] = $id;
+        return self::$items[$id];
+    }
+
+    public function delete(int $id): bool
+    {
+        if (!isset(self::$items[$id])) {
+            return false;
+        }
+        unset(self::$items[$id]);
+        return true;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
     "autoload": {
         "psr-4": {
             "app\\": "app/"
-        }
+        },
+        "files": ["app/core/helpers.php"]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "06a46f9a8b4b1774f04dc3ab596e08e8",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/index.php
+++ b/index.php
@@ -4,10 +4,22 @@ require __DIR__ . '/vendor/autoload.php';
 use app\core\Request;
 use app\core\Response;
 use app\core\Router;
+use app\controllers\HomeController;
+use app\controllers\ItemsController;
 
 $request = new Request();
 $response = new Response();
 $router = new Router();
+
+$home = new HomeController();
+$items = new ItemsController();
+
+$router->get('/', [$home, 'index']);
+$router->get('/items', [$items, 'index']);
+$router->get('/items/{id}', [$items, 'show']);
+$router->post('/items', [$items, 'create']);
+$router->put('/items/{id}', [$items, 'update']);
+$router->delete('/items/{id}', [$items, 'delete']);
 
 $router->dispatch($request, $response);
 $response->send();


### PR DESCRIPTION
## Summary
- replace query-based router with route table that supports parameters
- add helper `user_call_func` for dispatching
- implement view rendering class
- create items controller and model for REST API
- wire routes in `index.php`
- update README

## Testing
- `find . -name '*.php' | xargs -I{} php -l {}`
- `REQUEST_METHOD=GET REQUEST_URI=/ php index.php | head -n 1`
- `REQUEST_METHOD=GET REQUEST_URI=/items php index.php | head -n 1`


------
https://chatgpt.com/codex/tasks/task_e_6875faa2569c83229fe53bd701fad0e0