### PR TITLE
Encapsulate request/response creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ index.php       # Entry point and route registration
 
 ### Core components
 
-- **Router** – Minimal routing system supporting REST verbs.
+- **Router** – Minimal routing system supporting REST verbs. Internally it uses
+  factories to create immutable Request and Response objects.
 - **Request / Response** – Abstractions for HTTP requests and responses.
 - **View** – Renders PHP templates from the `views` directory.
 - **Database** – PDO-based singleton (not used by default). Modify models to use it for real databases.

--- a/app/core/RequestFactory.php
+++ b/app/core/RequestFactory.php
@@ -1,0 +1,17 @@
+<?php
+namespace app\core;
+
+class RequestFactory
+{
+    private Request $prototype;
+
+    public function __construct()
+    {
+        $this->prototype = new Request();
+    }
+
+    public function create(): RequestInterface
+    {
+        return clone $this->prototype;
+    }
+}

--- a/app/core/ResponseFactory.php
+++ b/app/core/ResponseFactory.php
@@ -1,0 +1,17 @@
+<?php
+namespace app\core;
+
+class ResponseFactory
+{
+    private Response $prototype;
+
+    public function __construct()
+    {
+        $this->prototype = new Response();
+    }
+
+    public function create(): ResponseInterface
+    {
+        return clone $this->prototype;
+    }
+}

--- a/index.php
+++ b/index.php
@@ -1,14 +1,10 @@
 <?php
 require __DIR__ . '/vendor/autoload.php';
 
-use app\core\Request;
-use app\core\Response;
 use app\core\Router;
 use app\controllers\HomeController;
 use app\controllers\ItemsController;
 
-$request = new Request();
-$response = new Response();
 $router = new Router();
 
 $home = new HomeController();
@@ -21,5 +17,6 @@ $router->post('/items', [$items, 'create']);
 $router->put('/items/{id}', [$items, 'update']);
 $router->delete('/items/{id}', [$items, 'delete']);
 
-$router->dispatch($request, $response);
+$response = $router->dispatch();
 $response->send();
+


### PR DESCRIPTION
## Summary
- encapsulate request & response instantiation inside `Router`
- create `RequestFactory` and `ResponseFactory` for cloning objects
- update entrypoint to use new dispatch behavior
- document router factories in README

## Testing
- `php -l index.php`
- `php -l app/core/Router.php`
- `php -l app/core/RequestFactory.php`
- `php -l app/core/ResponseFactory.php`
- `composer dump-autoload`
- `php index.php | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_687613169fe08322a536cd097ab47d72