### PR TITLE
Add model blueprint and caching service layer

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ app/
   controllers/  # Request handlers
   core/         # Minimal framework classes
   models/       # Data access layer
+  services/     # Business logic and caching
   views/        # HTML templates
 index.php       # Entry point and route registration
 ```
@@ -40,9 +41,13 @@ index.php       # Entry point and route registration
 
 `HomeController` renders a simple welcome page. `ItemsController` provides CRUD actions for items via JSON responses.
 
+### Services
+
+The service layer encapsulates business logic. `ItemsService` optionally caches model data using implementations of `CacheInterface` such as `ArrayCache`.
+
 ### Models
 
-`ItemsModel` stores an in-memory list of items. It can be replaced with a database-backed model. `HomeModel` returns a welcome message for the home page.
+`ItemsModel` stores an in-memory list of items. `BaseModel` is a blueprint that provides common CRUD query methods for database-backed models. `HomeModel` returns a welcome message for the home page.
 
 ### Views
 
@@ -59,4 +64,4 @@ Located in `app/views`. The `home.php` template displays the message passed by t
 
 ## Extending
 
-Use the provided core classes as a starting point for a custom MVC application. Create additional controllers and views as needed, or update the models to use a database connection via the `Database` class.
+Use the provided core classes as a starting point for a custom MVC application. Create additional controllers and views as needed. Models can extend `BaseModel` to work with the `Database` class. Business logic can live in services and take advantage of optional caching.

--- a/app/controllers/ItemsController.php
+++ b/app/controllers/ItemsController.php
@@ -4,26 +4,28 @@ namespace app\controllers;
 use app\core\RequestInterface;
 use app\core\ResponseInterface;
 use app\models\ItemsModel;
+use app\services\ItemsService;
+use app\services\ArrayCache;
 
 class ItemsController
 {
-    private ItemsModel $model;
+    private ItemsService $service;
 
-    public function __construct()
+    public function __construct(?ItemsService $service = null)
     {
-        $this->model = new ItemsModel();
+        $this->service = $service ?? new ItemsService(new ItemsModel(), new ArrayCache(), false);
     }
 
     public function index(RequestInterface $request, ResponseInterface $response): void
     {
-        $items = $this->model->all();
+        $items = $this->service->all();
         $response->setBody(json_encode($items));
     }
 
     public function show(RequestInterface $request, ResponseInterface $response): void
     {
         $id = (int)$request->getParam('id');
-        $item = $this->model->find($id);
+        $item = $this->service->find($id);
         if ($item) {
             $response->setBody(json_encode($item));
         } else {
@@ -34,7 +36,7 @@ class ItemsController
 
     public function create(RequestInterface $request, ResponseInterface $response): void
     {
-        $item = $this->model->create($request->getBody());
+        $item = $this->service->create($request->getBody());
         $response->setStatusCode(201);
         $response->setBody(json_encode($item));
     }
@@ -42,7 +44,7 @@ class ItemsController
     public function update(RequestInterface $request, ResponseInterface $response): void
     {
         $id = (int)$request->getParam('id');
-        $item = $this->model->update($id, $request->getBody());
+        $item = $this->service->update($id, $request->getBody());
         if ($item) {
             $response->setBody(json_encode($item));
         } else {
@@ -54,7 +56,7 @@ class ItemsController
     public function delete(RequestInterface $request, ResponseInterface $response): void
     {
         $id = (int)$request->getParam('id');
-        if ($this->model->delete($id)) {
+        if ($this->service->delete($id)) {
             $response->setStatusCode(204);
             $response->setBody('');
         } else {

--- a/app/controllers/ItemsController.php
+++ b/app/controllers/ItemsController.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace app\controllers;
 
 use app\core\RequestInterface;

--- a/app/models/BaseModel.php
+++ b/app/models/BaseModel.php
@@ -1,0 +1,65 @@
+<?php
+namespace app\models;
+
+use app\core\Database;
+use PDO;
+
+abstract class BaseModel
+{
+    protected string $table;
+
+    protected PDO $db;
+
+    public function __construct()
+    {
+        $this->db = Database::getInstance()->getConnection();
+    }
+
+    public function all(): array
+    {
+        $stmt = $this->db->query("SELECT * FROM {$this->table}");
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
+    public function find(int $id): ?array
+    {
+        $stmt = $this->db->prepare("SELECT * FROM {$this->table} WHERE id = :id");
+        $stmt->execute(['id' => $id]);
+        $result = $stmt->fetch(PDO::FETCH_ASSOC);
+        return $result ?: null;
+    }
+
+    public function create(array $data): array
+    {
+        $columns = array_keys($data);
+        $placeholders = array_map(fn($c) => ':' . $c, $columns);
+        $sql = sprintf(
+            'INSERT INTO %s (%s) VALUES (%s)',
+            $this->table,
+            implode(',', $columns),
+            implode(',', $placeholders)
+        );
+        $stmt = $this->db->prepare($sql);
+        $stmt->execute($data);
+        $id = (int)$this->db->lastInsertId();
+        return $this->find($id);
+    }
+
+    public function update(int $id, array $data): ?array
+    {
+        $assignments = implode(',', array_map(fn($c) => "$c = :$c", array_keys($data)));
+        $data['id'] = $id;
+        $sql = sprintf('UPDATE %s SET %s WHERE id = :id', $this->table, $assignments);
+        $stmt = $this->db->prepare($sql);
+        if ($stmt->execute($data)) {
+            return $this->find($id);
+        }
+        return null;
+    }
+
+    public function delete(int $id): bool
+    {
+        $stmt = $this->db->prepare("DELETE FROM {$this->table} WHERE id = :id");
+        return $stmt->execute(['id' => $id]);
+    }
+}

--- a/app/services/ArrayCache.php
+++ b/app/services/ArrayCache.php
@@ -1,0 +1,30 @@
+<?php
+namespace app\services;
+
+class ArrayCache implements CacheInterface
+{
+    private array $cache = [];
+    private array $expires = [];
+
+    public function get(string $key)
+    {
+        if (isset($this->cache[$key])) {
+            if ($this->expires[$key] === 0 || $this->expires[$key] > time()) {
+                return $this->cache[$key];
+            }
+            unset($this->cache[$key], $this->expires[$key]);
+        }
+        return null;
+    }
+
+    public function set(string $key, $value, int $ttl = 0): void
+    {
+        $this->cache[$key] = $value;
+        $this->expires[$key] = $ttl > 0 ? time() + $ttl : 0;
+    }
+
+    public function clear(string $key): void
+    {
+        unset($this->cache[$key], $this->expires[$key]);
+    }
+}

--- a/app/services/CacheInterface.php
+++ b/app/services/CacheInterface.php
@@ -1,0 +1,9 @@
+<?php
+namespace app\services;
+
+interface CacheInterface
+{
+    public function get(string $key);
+    public function set(string $key, $value, int $ttl = 0): void;
+    public function clear(string $key): void;
+}

--- a/app/services/ItemsService.php
+++ b/app/services/ItemsService.php
@@ -1,7 +1,9 @@
 <?php
+
 namespace app\services;
 
 use app\models\ItemsModel;
+use app\services\CacheInterface;
 
 class ItemsService
 {

--- a/app/services/ItemsService.php
+++ b/app/services/ItemsService.php
@@ -1,0 +1,89 @@
+<?php
+namespace app\services;
+
+use app\models\ItemsModel;
+
+class ItemsService
+{
+    private ItemsModel $model;
+    private ?CacheInterface $cache;
+    private bool $useCache;
+
+    public function __construct(?ItemsModel $model = null, ?CacheInterface $cache = null, bool $useCache = false)
+    {
+        $this->model = $model ?? new ItemsModel();
+        $this->cache = $cache;
+        $this->useCache = $useCache;
+    }
+
+    public function enableCache(bool $enabled): void
+    {
+        $this->useCache = $enabled;
+    }
+
+    public function all(): array
+    {
+        $key = 'items.all';
+        if ($this->useCache && $this->cache) {
+            $cached = $this->cache->get($key);
+            if ($cached !== null) {
+                return $cached;
+            }
+        }
+        $data = $this->model->all();
+        if ($this->useCache && $this->cache) {
+            $this->cache->set($key, $data);
+        }
+        return $data;
+    }
+
+    public function find(int $id): ?array
+    {
+        $key = "items.$id";
+        if ($this->useCache && $this->cache) {
+            $cached = $this->cache->get($key);
+            if ($cached !== null) {
+                return $cached;
+            }
+        }
+        $data = $this->model->find($id);
+        if ($data !== null && $this->useCache && $this->cache) {
+            $this->cache->set($key, $data);
+        }
+        return $data;
+    }
+
+    public function create(array $data): array
+    {
+        $item = $this->model->create($data);
+        if ($this->useCache && $this->cache) {
+            $this->cache->clear('items.all');
+            $this->cache->set('items.' . $item['id'], $item);
+        }
+        return $item;
+    }
+
+    public function update(int $id, array $data): ?array
+    {
+        $item = $this->model->update($id, $data);
+        if ($this->useCache && $this->cache) {
+            $this->cache->clear('items.all');
+            if ($item !== null) {
+                $this->cache->set("items.$id", $item);
+            } else {
+                $this->cache->clear("items.$id");
+            }
+        }
+        return $item;
+    }
+
+    public function delete(int $id): bool
+    {
+        $result = $this->model->delete($id);
+        if ($result && $this->useCache && $this->cache) {
+            $this->cache->clear('items.all');
+            $this->cache->clear("items.$id");
+        }
+        return $result;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,17 @@
 {
-    "name": "welldoc/mvc",
-    "description": "Simple MVC project",
-    "type": "project",
-    "require": {},
-    "autoload": {
-        "psr-4": {
-            "app\\": "app/"
-        }
+  "name": "welldoc/mvc",
+  "description": "Simple MVC project",
+  "scripts": {
+    "dev": "php -S localhost:8000 -t public"
+  },
+  "config": {
+    "process-timeout": 0
+  },
+  "type": "project",
+  "require": {},
+  "autoload": {
+    "psr-4": {
+      "app\\": "app/"
     }
+  }
 }

--- a/hello.txt
+++ b/hello.txt
@@ -1,0 +1,1 @@
+./app/core/Router.php

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,5 @@
 <?php
-require __DIR__ . '/vendor/autoload.php';
+require __DIR__ . '/../vendor/autoload.php';
 
 use app\core\Router;
 use app\controllers\HomeController;
@@ -19,4 +19,3 @@ $router->delete('/items/{id}', [$items, 'delete']);
 
 $response = $router->dispatch();
 $response->send();
-


### PR DESCRIPTION
## Summary
- create `BaseModel` blueprint with common CRUD methods
- introduce simple caching system using `CacheInterface` and `ArrayCache`
- add `ItemsService` to encapsulate business logic with optional caching
- update `ItemsController` to use the new service
- document service layer and blueprint model in README

## Testing
- `composer dump-autoload`
- `php -l app/models/BaseModel.php`
- `php -l app/services/CacheInterface.php`
- `php -l app/services/ArrayCache.php`
- `php -l app/services/ItemsService.php`
- `php -l app/controllers/ItemsController.php`


------
https://chatgpt.com/codex/tasks/task_e_68761ad68d98832291c235eead7b2a93