### PR TITLE
Add HTTP middleware layer with auth, CORS, and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ index.php       # Entry point and route registration
 - **Request / Response** – Abstractions for HTTP requests and responses.
 - **View** – Renders PHP templates from the `views` directory.
 - **Database** – PDO-based singleton (not used by default). Modify models to use it for real databases.
+- **Middleware** – Pipeline for cross-cutting concerns like logging, CORS, and auth.
 
 ### Controllers
 
@@ -47,6 +48,16 @@ index.php       # Entry point and route registration
 ### Views
 
 Located in `app/views`. The `home.php` template displays the message passed by the controller.
+
+### Middleware
+
+Middleware lives in `app/middleware` and is executed before route handlers. The default stack includes:
+
+- `LoggingMiddleware` – logs each request method and path.
+- `CorsMiddleware` – adds CORS headers and handles preflight `OPTIONS` requests.
+- `AuthMiddleware` – checks for an `Authorization: Bearer secret` header and rejects unauthorized requests.
+
+Register additional middleware in `public/index.php` using `$router->addMiddleware()`.
 
 ## API endpoints
 

--- a/app/core/MiddlewareInterface.php
+++ b/app/core/MiddlewareInterface.php
@@ -1,0 +1,7 @@
+<?php
+namespace app\core;
+
+interface MiddlewareInterface
+{
+    public function handle(RequestInterface $request, ResponseInterface $response, callable $next): void;
+}

--- a/app/core/MiddlewareInterface.php
+++ b/app/core/MiddlewareInterface.php
@@ -1,7 +1,17 @@
 <?php
 namespace app\core;
 
+/**
+ * Middleware components can inspect or modify the request/response
+ * and decide whether to continue to the next middleware in the chain.
+ */
 interface MiddlewareInterface
 {
+    /**
+     * Process an incoming request.
+     *
+     * Implementations may modify the request or response and must
+     * invoke the `$next` callable to pass control to the next middleware.
+     */
     public function handle(RequestInterface $request, ResponseInterface $response, callable $next): void;
 }

--- a/app/core/Request.php
+++ b/app/core/Request.php
@@ -7,6 +7,7 @@ class Request implements RequestInterface
     private string $uri;
     private array $query;
     private array $body;
+    private array $headers;
     private array $params = [];
 
     public function __construct()
@@ -15,6 +16,7 @@ class Request implements RequestInterface
         $this->uri = strtok($_SERVER['REQUEST_URI'] ?? '/', '?');
         $this->query = $_GET;
         $this->body = $_POST;
+        $this->headers = function_exists('getallheaders') ? getallheaders() : [];
     }
 
     public function getMethod(): string
@@ -35,6 +37,16 @@ class Request implements RequestInterface
     public function getBody(): array
     {
         return $this->body;
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+
+    public function getHeader(string $name): ?string
+    {
+        return $this->headers[$name] ?? null;
     }
 
     public function setParams(array $params): void

--- a/app/core/RequestInterface.php
+++ b/app/core/RequestInterface.php
@@ -10,4 +10,6 @@ interface RequestInterface
     public function setParams(array $params): void;
     public function getParam(string $name): ?string;
     public function getParams(): array;
+    public function getHeaders(): array;
+    public function getHeader(string $name): ?string;
 }

--- a/app/core/Response.php
+++ b/app/core/Response.php
@@ -5,6 +5,7 @@ class Response implements ResponseInterface
 {
     private int $statusCode = 200;
     private string $body = '';
+    private array $headers = [];
 
     public function setStatusCode(int $code): void
     {
@@ -16,9 +17,17 @@ class Response implements ResponseInterface
         $this->body = $body;
     }
 
+    public function addHeader(string $name, string $value): void
+    {
+        $this->headers[$name] = $value;
+    }
+
     public function send(): void
     {
         http_response_code($this->statusCode);
+        foreach ($this->headers as $name => $value) {
+            header($name . ': ' . $value);
+        }
         echo $this->body;
     }
 }

--- a/app/core/ResponseInterface.php
+++ b/app/core/ResponseInterface.php
@@ -5,5 +5,6 @@ interface ResponseInterface
 {
     public function setStatusCode(int $code): void;
     public function setBody(string $body): void;
+    public function addHeader(string $name, string $value): void;
     public function send(): void;
 }

--- a/app/middleware/AuthMiddleware.php
+++ b/app/middleware/AuthMiddleware.php
@@ -1,0 +1,20 @@
+<?php
+namespace app\middleware;
+
+use app\core\MiddlewareInterface;
+use app\core\RequestInterface;
+use app\core\ResponseInterface;
+
+class AuthMiddleware implements MiddlewareInterface
+{
+    public function handle(RequestInterface $request, ResponseInterface $response, callable $next): void
+    {
+        $auth = $request->getHeader('Authorization');
+        if ($auth !== 'Bearer secret') {
+            $response->setStatusCode(401);
+            $response->setBody('Unauthorized');
+            return;
+        }
+        $next($request, $response);
+    }
+}

--- a/app/middleware/AuthMiddleware.php
+++ b/app/middleware/AuthMiddleware.php
@@ -5,6 +5,12 @@ use app\core\MiddlewareInterface;
 use app\core\RequestInterface;
 use app\core\ResponseInterface;
 
+/**
+ * Very basic authorization middleware.
+ *
+ * Expects the `Authorization` header to contain `Bearer secret` and
+ * returns a 401 response if the header is missing or incorrect.
+ */
 class AuthMiddleware implements MiddlewareInterface
 {
     public function handle(RequestInterface $request, ResponseInterface $response, callable $next): void

--- a/app/middleware/CorsMiddleware.php
+++ b/app/middleware/CorsMiddleware.php
@@ -5,6 +5,9 @@ use app\core\MiddlewareInterface;
 use app\core\RequestInterface;
 use app\core\ResponseInterface;
 
+/**
+ * Adds CORS headers and short-circuits preflight `OPTIONS` requests.
+ */
 class CorsMiddleware implements MiddlewareInterface
 {
     public function handle(RequestInterface $request, ResponseInterface $response, callable $next): void

--- a/app/middleware/CorsMiddleware.php
+++ b/app/middleware/CorsMiddleware.php
@@ -1,0 +1,23 @@
+<?php
+namespace app\middleware;
+
+use app\core\MiddlewareInterface;
+use app\core\RequestInterface;
+use app\core\ResponseInterface;
+
+class CorsMiddleware implements MiddlewareInterface
+{
+    public function handle(RequestInterface $request, ResponseInterface $response, callable $next): void
+    {
+        $response->addHeader('Access-Control-Allow-Origin', '*');
+        $response->addHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+        $response->addHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization');
+
+        if ($request->getMethod() === 'OPTIONS') {
+            $response->setStatusCode(204);
+            return;
+        }
+
+        $next($request, $response);
+    }
+}

--- a/app/middleware/LoggingMiddleware.php
+++ b/app/middleware/LoggingMiddleware.php
@@ -1,0 +1,15 @@
+<?php
+namespace app\middleware;
+
+use app\core\MiddlewareInterface;
+use app\core\RequestInterface;
+use app\core\ResponseInterface;
+
+class LoggingMiddleware implements MiddlewareInterface
+{
+    public function handle(RequestInterface $request, ResponseInterface $response, callable $next): void
+    {
+        error_log($request->getMethod() . ' ' . $request->getUri());
+        $next($request, $response);
+    }
+}

--- a/app/middleware/LoggingMiddleware.php
+++ b/app/middleware/LoggingMiddleware.php
@@ -5,6 +5,9 @@ use app\core\MiddlewareInterface;
 use app\core\RequestInterface;
 use app\core\ResponseInterface;
 
+/**
+ * Logs each incoming request using PHP's `error_log`.
+ */
 class LoggingMiddleware implements MiddlewareInterface
 {
     public function handle(RequestInterface $request, ResponseInterface $response, callable $next): void

--- a/public/index.php
+++ b/public/index.php
@@ -4,8 +4,14 @@ require __DIR__ . '/../vendor/autoload.php';
 use app\core\Router;
 use app\controllers\HomeController;
 use app\controllers\ItemsController;
+use app\middleware\AuthMiddleware;
+use app\middleware\CorsMiddleware;
+use app\middleware\LoggingMiddleware;
 
 $router = new Router();
+$router->addMiddleware(new LoggingMiddleware());
+$router->addMiddleware(new CorsMiddleware());
+$router->addMiddleware(new AuthMiddleware());
 
 $home = new HomeController();
 $items = new ItemsController();


### PR DESCRIPTION
## Summary
- add middleware interface and implementations for logging, CORS, and auth
- extend request/response to handle headers
- integrate middleware pipeline into router and bootstrap

## Testing
- `composer dump-autoload`
- `php -l app/core/Request.php`
- `php public/index.php >/tmp/app.out 2>&1; cat -n /tmp/app.out`


------
https://chatgpt.com/codex/tasks/task_e_688ef9c4934c83228ed2994683442a94